### PR TITLE
Make the cpp stubs build way quieter

### DIFF
--- a/eigen_cpp/dune
+++ b/eigen_cpp/dune
@@ -30,6 +30,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     -Wno-invalid-partial-specialization
     -Wno-extern-c-compat
     -Wno-c++11-long-long
+    -Wno-ignored-attributes
     %s
    )
   )


### PR DESCRIPTION
Unnecessary `ignored-attributes` warnings are polluting all the build logs. This change should make all our test work again.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>