### PR TITLE
fix linking for win32

### DIFF
--- a/eigen/dune
+++ b/eigen/dune
@@ -38,6 +38,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (names eigen_utils_stubs ffi_eigen_generated_stub)
   (flags :standard %s -I../eigen_cpp/lib)
   )
- (c_library_flags :standard -lstdc++)
+ (c_library_flags :standard)
 )
 |} eigen_flags


### PR DESCRIPTION
Removed `-lstdc++` flag for C-stubs (still present for C++ part).
Tested on Windows 10 (mingw32-w64 toolchain) and Ubuntu 20.04 (on WSL2). It might need some more testing on other platforms.