### PR TITLE
build: add architecture dependent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ If you have questions or suggestions, please contact me via [Email](liang.wang@c
 
 ## Optional configuration
 
-You can customise the optimization flags used to compile the C++ libeigen by setting `EIGENCPP_OPTFLAGS`, the default value is
+You can customise the optimization flags used to compile the C++ libeigen by setting `EIGENCPP_OPTFLAGS`, the default value for `x86_64` is
 ```
 EIGENCPP_OPTFLAGS = -Ofast -march=native -funroll-loops -ffast-math
 ```
 
-Similarly you can customise the optimization flags used to compile the eigen library by setting `EIGEN_FLAGS`, the default value is
+Similarly you can customise the optimization flags used to compile the eigen library by setting `EIGEN_FLAGS`, the default value for `x86_64` is
 ```
 EIGEN_FLAGS = -O3 -Ofast -march=native -funroll-loops -ffast-math
 ```

--- a/eigen/configure/configure.ml
+++ b/eigen/configure/configure.ml
@@ -1,0 +1,106 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2022 Liang Wang <liang@ocaml.xyz>
+ *)
+
+module C = Configurator.V1
+
+let detect_system_header =
+  {|
+  #if __APPLE__
+    #include <TargetConditionals.h>
+    #if TARGET_OS_IPHONE
+      #define PLATFORM_NAME "ios"
+    #else
+      #define PLATFORM_NAME "mac"
+    #endif
+  #elif __linux__
+    #if __ANDROID__
+      #define PLATFORM_NAME "android"
+    #else
+      #define PLATFORM_NAME "linux"
+    #endif
+  #elif WIN32
+    #define PLATFORM_NAME "windows"
+  #endif
+|}
+
+let detect_system_arch =
+  {|
+  #if __x86_64__
+    #define PLATFORM_ARCH "x86_64"
+  #elif __i386__
+    #define PLATFORM_ARCH "x86"
+  #elif __aarch64__
+    #define PLATFORM_ARCH "arm64"
+  #elif __arm__
+    #define PLATFORM_ARCH "arm"
+  #else
+    #define PLATFORM_ARCH "unknown"
+  #endif
+|}
+
+let default_cflags c =
+  try
+    Sys.getenv "EIGEN_FLAGS"
+    |> String.split_on_char ' '
+    |> List.filter (fun s -> String.trim s <> "")
+  with
+  | Not_found ->
+    let os =
+      let header =
+        let file = Filename.temp_file "discover" "os.h" in
+        let fd = open_out file in
+        output_string fd detect_system_header;
+        close_out fd;
+        file
+      in
+      let platform =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_NAME", String ]
+      in
+      match List.map snd platform with
+      | [ String "android" ] -> `android
+      | [ String "ios" ]     -> `ios
+      | [ String "linux" ]   -> `linux
+      | [ String "mac" ]     -> `mac
+      | [ String "windows" ] -> `windows
+      | _                    -> `unknown
+    in
+    let arch =
+      let header =
+        let file = Filename.temp_file "discover" "arch.h" in
+        let fd = open_out file in
+        output_string fd detect_system_arch;
+        close_out fd;
+        file
+      in
+      let arch =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_ARCH", String ]
+      in
+      match List.map snd arch with
+      | [ String "x86_64" ] -> `x86_64
+      | [ String "x86" ] -> `x86
+      | [ String "arm64" ] -> `arm64
+      | [ String "arm" ] -> `arm
+      | _ -> `unknown
+    in
+    [ (* Basic optimisation *) "-g"; "-O3"; "-Ofast" ]
+    @ (match arch, os with
+      | `arm64, `mac -> [ "-mcpu=apple-m1" ]
+      | `arm64, _    -> [ "-march=native" ]
+      | `x86_64, _   -> [ "-march=native"; "-mfpmath=sse"; "-msse2" ]
+      | _            -> [])
+    @ [ (* Experimental switches, -ffast-math may break IEEE754 semantics*)
+        "-funroll-loops"
+      ; "-ffast-math"
+      ]
+
+let () =
+  C.main ~name:"eigen" (fun c ->
+    (* configure compile options *)
+    let libs = [] in
+    let cflags = default_cflags c in
+    (* configure ocaml options *)
+    (* assemble default config *)
+    let conf : C.Pkg_config.package_conf = { cflags; libs } in
+    C.Flags.write_sexp "c_flags.sexp" conf.cflags)

--- a/eigen/configure/dune
+++ b/eigen/configure/dune
@@ -1,0 +1,3 @@
+(executable
+ (name configure)
+ (libraries dune.configurator))

--- a/eigen/dune
+++ b/eigen/dune
@@ -1,32 +1,25 @@
-(* -*- tuareg -*- *)
-
-let eigen_flags =
-  match Sys.getenv "EIGEN_FLAGS" with
-  | s -> String.trim s
-  | exception Not_found -> "-O3 -Ofast -march=native -funroll-loops -ffast-math"
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (rule
  (targets ffi_eigen_generated.ml)
  (deps ../bindings/ffi_eigen_stubgen.exe)
  (action
   (with-stdout-to
-   %%{targets}
-   (run %%{deps} -ml)
-  )
- )
-)
+   %{targets}
+   (run %{deps} -ml))))
 
 (rule
  (targets ffi_eigen_generated_stub.c)
  (deps ../bindings/ffi_eigen_stubgen.exe)
  (action
   (with-stdout-to
-   %%{targets}
-   (run %%{deps} -c)
-  )
- )
-)
+   %{targets}
+   (run %{deps} -c))))
+
+(rule
+ (targets c_flags.sexp)
+ (deps
+  (:deps-conf configure/configure.exe))
+ (action
+  (run %{deps-conf})))
 
 (library
  (name eigen)
@@ -38,7 +31,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (language c)
   (names eigen_utils_stubs ffi_eigen_generated_stub)
   (include_dirs ../eigen_cpp/lib)
-  (flags :standard %s)
-  )
-)
-|} eigen_flags
+  (flags
+   :standard
+   (:include c_flags.sexp))))

--- a/eigen_cpp/configure/configure.ml
+++ b/eigen_cpp/configure/configure.ml
@@ -1,0 +1,120 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2022 Liang Wang <liang@ocaml.xyz>
+ *)
+
+module C = Configurator.V1
+
+let detect_system_header =
+  {|
+  #if __APPLE__
+    #include <TargetConditionals.h>
+    #if TARGET_OS_IPHONE
+      #define PLATFORM_NAME "ios"
+    #else
+      #define PLATFORM_NAME "mac"
+    #endif
+  #elif __linux__
+    #if __ANDROID__
+      #define PLATFORM_NAME "android"
+    #else
+      #define PLATFORM_NAME "linux"
+    #endif
+  #elif WIN32
+    #define PLATFORM_NAME "windows"
+  #endif
+|}
+
+let detect_system_arch =
+  {|
+  #if __x86_64__
+    #define PLATFORM_ARCH "x86_64"
+  #elif __i386__
+    #define PLATFORM_ARCH "x86"
+  #elif __aarch64__
+    #define PLATFORM_ARCH "arm64"
+  #elif __arm__
+    #define PLATFORM_ARCH "arm"
+  #else
+    #define PLATFORM_ARCH "unknown"
+  #endif
+|}
+
+let default_cppflags c =
+  let devflags =
+    match Sys.getenv "EIGENCPP_DIAGNOSTIC" with
+    | s -> 
+      ("-Wall -Wno-invalid-partial-specialization -Wno-extern-c-compat -Wno-c++11-long-long -Wno-ignored-attributes "^s)
+      |> String.split_on_char ' '
+      |> List.filter (fun s -> String.trim s <> "")
+    | exception Not_found -> ["-W"; "-Wno-invalid-partial-specialization"]
+  in
+  try
+    String.trim (Sys.getenv "EIGEN_OPTFLAGS")
+    |> String.split_on_char ' '
+    |> List.filter (fun s -> String.trim s <> "")
+  with
+  | Not_found ->
+    let os =
+      let header =
+        let file = Filename.temp_file "discover" "os.h" in
+        let fd = open_out file in
+        output_string fd detect_system_header;
+        close_out fd;
+        file
+      in
+      let platform =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_NAME", String ]
+      in
+      match List.map snd platform with
+      | [ String "android" ] -> `android
+      | [ String "ios" ]     -> `ios
+      | [ String "linux" ]   -> `linux
+      | [ String "mac" ]     -> `mac
+      | [ String "windows" ] -> `windows
+      | _                    -> `unknown
+    in
+    let arch =
+      let header =
+        let file = Filename.temp_file "discover" "arch.h" in
+        let fd = open_out file in
+        output_string fd detect_system_arch;
+        close_out fd;
+        file
+      in
+      let arch =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_ARCH", String ]
+      in
+      match List.map snd arch with
+      | [ String "x86_64" ] -> `x86_64
+      | [ String "x86" ] -> `x86
+      | [ String "arm64" ] -> `arm64
+      | [ String "arm" ] -> `arm
+      | _ -> `unknown
+    in
+    [ 
+      "-fPIC"
+    ; "-ansi"
+    ; "-pedantic"
+    ; "-O3"
+    ; "-std=c++11"
+    ; "-lstdc++"
+    ] @ (match arch, os with
+      | `arm64, `mac -> [ "-mcpu=apple-m1" ]
+      | `arm64, _    -> [ "-march=native" ]
+      | `x86_64, _   -> [ "-march=native"; "-mfpmath=sse"; "-msse2" ]
+      | _            -> [])
+    @ [ (* Experimental switches, -ffast-math may break IEEE754 semantics*)
+        "-funroll-loops"
+      ; "-ffast-math"
+      ]
+    @ devflags
+
+let () =
+  C.main ~name:"eigen_cpp" (fun c ->
+    (* configure compile options *)
+    let libs = [] in
+    let cflags = default_cppflags c in
+    (* assemble default config *)
+    let conf : C.Pkg_config.package_conf = { cflags; libs } in
+    C.Flags.write_sexp "cpp_flags.sexp" conf.cflags)

--- a/eigen_cpp/configure/dune
+++ b/eigen_cpp/configure/dune
@@ -1,0 +1,5 @@
+(include_subdirs no)
+
+(executable
+ (name configure)
+ (libraries dune.configurator))

--- a/eigen_cpp/dune
+++ b/eigen_cpp/dune
@@ -1,20 +1,11 @@
-(* -*- tuareg -*- *)
-
-let optflags =
-  match Sys.getenv "EIGENCPP_OPTFLAGS" with
-  | s ->
-    s
-  | exception Not_found ->
-    "-Ofast -march=native -funroll-loops -ffast-math"
-
-let devflags =
-  match Sys.getenv "EIGENCPP_DIAGNOSTIC" with
-  | s -> "-Wall -Wno-invalid-partial-specialization -Wno-extern-c-compat -Wno-c++11-long-long -Wno-ignored-attributes "^s
-  | exception Not_found -> "-w -Wno-invalid-partial-specialization"
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
-
 (include_subdirs unqualified)
+
+(rule
+ (targets cpp_flags.sexp)
+ (deps
+  (:deps-conf configure/configure.exe))
+ (action
+  (run %{deps-conf})))
 
 (foreign_library
  (archive_name eigen_cpp_stubs)
@@ -22,16 +13,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
  (names eigen_tensor eigen_dsmat eigen_spmat)
  (include_dirs lib lib/unsupported)
  (flags
-   :standard
-   -fPIC
-   -ansi
-   -pedantic
-   -O3
-   -std=c++11
-   -lstdc++
-   %s
-   %s
-  )
- )
-
-|} devflags optflags
+  :standard
+  (:include cpp_flags.sexp)))


### PR DESCRIPTION
This should fix the build for ARM64, in particular apple M1.
With this, https://github.com/owlbarn/owl/pull/609 should compile fine
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>