### PR TITLE
 build: add architecture dependent configuration (for release 0.3.1)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,8 +12,8 @@ jobs:
           - ubuntu-20.04
           - windows-latest
         ocaml-version:
-          - 4.10.1
-          - 4.11.1
+          - 4.10.x
+          - 4.13.x
 
     env:
       OCAML_VERSION: ${{ matrix.ocaml-version }}
@@ -25,22 +25,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cached Infra
-        uses: actions/cache@v2
-        env:
-          cache-name: cached-opam
-        with:
-          path: |
-           ~/.opam
-           _build
-           C:\cygwin
-          key: ${{ matrix.os }}-${{ matrix.ocaml-version }}-${{ env.cache-name }}-${{ hashFiles('**/*.opam*') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.ocaml-version }}-${{ env.cache-name }}-
-            ${{ matrix.os }}-${{ matrix.ocaml-version }}-
-            ${{ matrix.os }}-
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: avsm/setup-ocaml@v2
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 

--- a/eigen.opam
+++ b/eigen.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "ctypes" {>= "0.14.0"}
   "dune" {>= "2.0.0"}
+  "dune-configurator"
 ]
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:

--- a/eigen/configure/configure.ml
+++ b/eigen/configure/configure.ml
@@ -1,0 +1,106 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2022 Liang Wang <liang@ocaml.xyz>
+ *)
+
+module C = Configurator.V1
+
+let detect_system_header =
+  {|
+  #if __APPLE__
+    #include <TargetConditionals.h>
+    #if TARGET_OS_IPHONE
+      #define PLATFORM_NAME "ios"
+    #else
+      #define PLATFORM_NAME "mac"
+    #endif
+  #elif __linux__
+    #if __ANDROID__
+      #define PLATFORM_NAME "android"
+    #else
+      #define PLATFORM_NAME "linux"
+    #endif
+  #elif WIN32
+    #define PLATFORM_NAME "windows"
+  #endif
+|}
+
+let detect_system_arch =
+  {|
+  #if __x86_64__
+    #define PLATFORM_ARCH "x86_64"
+  #elif __i386__
+    #define PLATFORM_ARCH "x86"
+  #elif __aarch64__
+    #define PLATFORM_ARCH "arm64"
+  #elif __arm__
+    #define PLATFORM_ARCH "arm"
+  #else
+    #define PLATFORM_ARCH "unknown"
+  #endif
+|}
+
+let default_cflags c =
+  try
+    Sys.getenv "EIGEN_FLAGS"
+    |> String.split_on_char ' '
+    |> List.filter (fun s -> String.trim s <> "")
+  with
+  | Not_found ->
+    let os =
+      let header =
+        let file = Filename.temp_file "discover" "os.h" in
+        let fd = open_out file in
+        output_string fd detect_system_header;
+        close_out fd;
+        file
+      in
+      let platform =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_NAME", String ]
+      in
+      match List.map snd platform with
+      | [ String "android" ] -> `android
+      | [ String "ios" ]     -> `ios
+      | [ String "linux" ]   -> `linux
+      | [ String "mac" ]     -> `mac
+      | [ String "windows" ] -> `windows
+      | _                    -> `unknown
+    in
+    let arch =
+      let header =
+        let file = Filename.temp_file "discover" "arch.h" in
+        let fd = open_out file in
+        output_string fd detect_system_arch;
+        close_out fd;
+        file
+      in
+      let arch =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_ARCH", String ]
+      in
+      match List.map snd arch with
+      | [ String "x86_64" ] -> `x86_64
+      | [ String "x86" ] -> `x86
+      | [ String "arm64" ] -> `arm64
+      | [ String "arm" ] -> `arm
+      | _ -> `unknown
+    in
+    [ (* Basic optimisation *) "-g"; "-O3"; "-Ofast" ]
+    @ (match arch, os with
+      | `arm64, `mac -> [ "-mcpu=apple-m1" ]
+      | `arm64, _    -> [ "-march=native" ]
+      | `x86_64, _   -> [ "-march=native"; "-mfpmath=sse"; "-msse2" ]
+      | _            -> [])
+    @ [ (* Experimental switches, -ffast-math may break IEEE754 semantics*)
+        "-funroll-loops"
+      ; "-ffast-math"
+      ]
+
+let () =
+  C.main ~name:"eigen" (fun c ->
+    (* configure compile options *)
+    let libs = [] in
+    let cflags = default_cflags c in
+    (* configure ocaml options *)
+    (* assemble default config *)
+    let conf : C.Pkg_config.package_conf = { cflags; libs } in
+    C.Flags.write_sexp "c_flags.sexp" conf.cflags)

--- a/eigen/configure/dune
+++ b/eigen/configure/dune
@@ -1,0 +1,3 @@
+(executable
+ (name configure)
+ (libraries dune.configurator))

--- a/eigen/dune
+++ b/eigen/dune
@@ -1,32 +1,25 @@
-(* -*- tuareg -*- *)
-
-let eigen_flags =
-  match Sys.getenv "EIGEN_FLAGS" with
-  | s -> String.trim s
-  | exception Not_found -> "-O3 -Ofast -march=native -funroll-loops -ffast-math"
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (rule
  (targets ffi_eigen_generated.ml)
  (deps ../bindings/ffi_eigen_stubgen.exe)
  (action
   (with-stdout-to
-   %%{targets}
-   (run %%{deps} -ml)
-  )
- )
-)
+   %{targets}
+   (run %{deps} -ml))))
 
 (rule
  (targets ffi_eigen_generated_stub.c)
  (deps ../bindings/ffi_eigen_stubgen.exe)
  (action
   (with-stdout-to
-   %%{targets}
-   (run %%{deps} -c)
-  )
- )
-)
+   %{targets}
+   (run %{deps} -c))))
+
+(rule
+ (targets c_flags.sexp)
+ (deps
+  (:deps-conf configure/configure.exe))
+ (action
+  (run %{deps-conf})))
 
 (library
  (name eigen)
@@ -36,8 +29,8 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
  (foreign_stubs
   (language c)
   (names eigen_utils_stubs ffi_eigen_generated_stub)
-  (flags :standard %s -I../eigen_cpp/lib)
-  )
- (c_library_flags :standard)
-)
-|} eigen_flags
+  (flags
+   :standard
+   (:include c_flags.sexp)
+   -I../eigen_cpp/lib))
+  (c_library_flags :standard))

--- a/eigen_cpp/configure/configure.ml
+++ b/eigen_cpp/configure/configure.ml
@@ -42,7 +42,7 @@ let detect_system_arch =
 
 let default_cppflags c =
   try
-    String.trim (Sys.getenv "EIGEN_OPTFLAGS")
+    String.trim (Sys.getenv "EIGENCPP_OPTFLAGS")
     |> String.split_on_char ' '
     |> List.filter (fun s -> String.trim s <> "")
   with

--- a/eigen_cpp/configure/configure.ml
+++ b/eigen_cpp/configure/configure.ml
@@ -1,0 +1,110 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2022 Liang Wang <liang@ocaml.xyz>
+ *)
+
+module C = Configurator.V1
+
+let detect_system_header =
+  {|
+  #if __APPLE__
+    #include <TargetConditionals.h>
+    #if TARGET_OS_IPHONE
+      #define PLATFORM_NAME "ios"
+    #else
+      #define PLATFORM_NAME "mac"
+    #endif
+  #elif __linux__
+    #if __ANDROID__
+      #define PLATFORM_NAME "android"
+    #else
+      #define PLATFORM_NAME "linux"
+    #endif
+  #elif WIN32
+    #define PLATFORM_NAME "windows"
+  #endif
+|}
+
+let detect_system_arch =
+  {|
+  #if __x86_64__
+    #define PLATFORM_ARCH "x86_64"
+  #elif __i386__
+    #define PLATFORM_ARCH "x86"
+  #elif __aarch64__
+    #define PLATFORM_ARCH "arm64"
+  #elif __arm__
+    #define PLATFORM_ARCH "arm"
+  #else
+    #define PLATFORM_ARCH "unknown"
+  #endif
+|}
+
+let default_cppflags c =
+  try
+    String.trim (Sys.getenv "EIGEN_OPTFLAGS")
+    |> String.split_on_char ' '
+    |> List.filter (fun s -> String.trim s <> "")
+  with
+  | Not_found ->
+    let os =
+      let header =
+        let file = Filename.temp_file "discover" "os.h" in
+        let fd = open_out file in
+        output_string fd detect_system_header;
+        close_out fd;
+        file
+      in
+      let platform =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_NAME", String ]
+      in
+      match List.map snd platform with
+      | [ String "android" ] -> `android
+      | [ String "ios" ]     -> `ios
+      | [ String "linux" ]   -> `linux
+      | [ String "mac" ]     -> `mac
+      | [ String "windows" ] -> `windows
+      | _                    -> `unknown
+    in
+    let arch =
+      let header =
+        let file = Filename.temp_file "discover" "arch.h" in
+        let fd = open_out file in
+        output_string fd detect_system_arch;
+        close_out fd;
+        file
+      in
+      let arch =
+        C.C_define.import c ~includes:[ header ] [ "PLATFORM_ARCH", String ]
+      in
+      match List.map snd arch with
+      | [ String "x86_64" ] -> `x86_64
+      | [ String "x86" ] -> `x86
+      | [ String "arm64" ] -> `arm64
+      | [ String "arm" ] -> `arm
+      | _ -> `unknown
+    in
+    [ 
+      "-fPIC"
+    ; "-ansi"
+    ; "-pedantic"
+    ; "-O3"
+    ; "-std=c++11"
+    ] @ (match arch, os with
+      | `arm64, `mac -> [ "-mcpu=apple-m1" ]
+      | `arm64, _    -> [ "-march=native" ]
+      | `x86_64, _   -> [ "-march=native"; "-mfpmath=sse"; "-msse2" ]
+      | _            -> [])
+    @ [ (* Experimental switches, -ffast-math may break IEEE754 semantics*)
+        "-funroll-loops"
+      ; "-ffast-math"
+      ]
+
+let () =
+  C.main ~name:"eigen_cpp" (fun c ->
+    (* configure compile options *)
+    let libs = [] in
+    let cflags = default_cppflags c in
+    (* assemble default config *)
+    let conf : C.Pkg_config.package_conf = { cflags; libs } in
+    C.Flags.write_sexp "cpp_flags.sexp" conf.cflags)

--- a/eigen_cpp/configure/dune
+++ b/eigen_cpp/configure/dune
@@ -1,0 +1,5 @@
+(include_subdirs no)
+
+(executable
+ (name configure)
+ (libraries dune.configurator))

--- a/eigen_cpp/dune
+++ b/eigen_cpp/dune
@@ -1,20 +1,11 @@
-(* -*- tuareg -*- *)
-
-let optflags =
-  match Sys.getenv "EIGENCPP_OPTFLAGS" with
-  | s ->
-    s
-  | exception Not_found ->
-    "-Ofast -march=native -funroll-loops -ffast-math"
-
-let devflags =
-  match Sys.getenv "EIGENCPP_DIAGNOSTIC" with
-  | s -> "-Wall -Wno-invalid-partial-specialization -Wno-extern-c-compat -Wno-c++11-long-long -Wno-ignored-attributes "^s
-  | exception Not_found -> "-w -Wno-invalid-partial-specialization"
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
-
 (include_subdirs unqualified)
+
+(rule
+ (targets cpp_flags.sexp)
+ (deps
+  (:deps-conf configure/configure.exe))
+ (action
+  (run %{deps-conf})))
 
 (library
  (name eigen_cpp_stubs)
@@ -25,17 +16,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (names eigen_tensor eigen_dsmat eigen_spmat)
   (include_dirs lib lib/unsupported)
   (flags
-    :standard
-    -fPIC
-    -ansi
-    -pedantic
-    -O3
-    -std=c++11
-    %s
-    %s
-   )
-  )
- (c_library_flags :standard -lstdc++)
- )
-
-|} devflags optflags
+   :standard
+   (:include cpp_flags.sexp)))
+ (c_library_flags :standard -lstdc++))

--- a/eigen_cpp/lib/unsupported/Eigen/CXX11/src/Tensor/TensorStorage.h
+++ b/eigen_cpp/lib/unsupported/Eigen/CXX11/src/Tensor/TensorStorage.h
@@ -31,12 +31,12 @@ namespace Eigen {
   *
   * \sa Tensor
   */
-template<typename T, typename Dimensions, int Options_> class TensorStorage;
+template<typename T, typename Dimensions, int Options> class TensorStorage;
 
 
 // Pure fixed-size storage
-template<typename T, int Options_, typename FixedDimensions>
-class TensorStorage<T, FixedDimensions, Options_>
+template<typename T, typename FixedDimensions, int Options_>
+class TensorStorage
 {
  private:
   static const std::size_t Size = FixedDimensions::total_size;
@@ -66,7 +66,7 @@ class TensorStorage<T, FixedDimensions, Options_>
 
 
 // pure dynamic
-template<typename T, int Options_, typename IndexType, int NumIndices_>
+template<typename T, typename IndexType, int NumIndices_, int Options_>
 class TensorStorage<T, DSizes<IndexType, NumIndices_>, Options_>
 {
   public:


### PR DESCRIPTION
This adds the architecture-dependent build to `eigen.0.3.0`. It does not take advantage of the new dune features used in master, but on the other hand builds fine and seems to work well on my tests