### PR TITLE
configure: add missing unknown platform

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Hack Git CRLF for ocaml/setup-ocaml issue #529
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        run: |
+          & "C:\Program Files\Git\bin\git.exe" config --system core.autocrlf input
+
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v2
         with:

--- a/eigen/configure/configure.ml
+++ b/eigen/configure/configure.ml
@@ -22,6 +22,8 @@ let detect_system_header =
     #endif
   #elif WIN32
     #define PLATFORM_NAME "windows"
+  #else
+    #define PLATFORM_NAME "unknown"
   #endif
 |}
 

--- a/eigen_cpp/configure/configure.ml
+++ b/eigen_cpp/configure/configure.ml
@@ -22,6 +22,8 @@ let detect_system_header =
     #endif
   #elif WIN32
     #define PLATFORM_NAME "windows"
+  #else
+    #define PLATFORM_NAME "unknown"
   #endif
 |}
 


### PR DESCRIPTION
This prevents unnecessary automatic failures on *BSD

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>